### PR TITLE
Add substructural types

### DIFF
--- a/src/assoclist.rs
+++ b/src/assoclist.rs
@@ -42,13 +42,20 @@ impl<K: Clone + PartialEq, V: Clone> AssocList<K, V> {
         self.inner.last()
     }
 
+    pub fn remove(&mut self, item: &K) -> Option<V> {
+        self.find(item).map(|idx| self.inner.remove(idx).1)
+    }
+
     pub fn lookup(&self, item: &K) -> Option<V> {
-        for (key, val) in self.inner.iter().rev() {
-            if key == item {
-                return Some(val.clone());
-            }
-        }
-        None
+        self.find(item).map(|idx| self.inner[idx].1.clone())
+    }
+
+    fn find(&self, item: &K) -> Option<usize> {
+        self.inner
+            .iter()
+            .rev()
+            .position(|(key, _)| key == item)
+            .map(|idx| self.inner.len() - 1 - idx)
     }
 
     pub fn map_val<T, E, F>(&self, mut func: F) -> Result<AssocList<K, T>, E>
@@ -85,6 +92,20 @@ impl AssocList<String, Term> {
         kind_ctx: &mut KindContext,
     ) -> Result<AssocList<String, Type>, TypeError> {
         self.map_val(|ty| tc(ty, type_ctx, kind_ctx))
+    }
+}
+
+impl fmt::Display for AssocList<String, Term> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.inner
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,8 @@ pub enum TypeError {
     KindError(String),
     // Tried to use a value that has a non proper type
     NonProper,
+    AbsContainment,
+    Linear(String),
 }
 
 impl fmt::Display for TypeError {
@@ -118,6 +120,8 @@ impl fmt::Display for TypeError {
             }
             TypeError::KindError(ref s) => write!(f, "{}", s),
             TypeError::NonProper => write!(f, "Values can only have proper types"),
+            TypeError::AbsContainment => write!(f, "Unrestricted functions cannot have linear variables in scope"),
+            TypeError::Linear(ref s) => write!(f, "Linear variable {} must be used exactly once", s),
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -162,7 +162,9 @@ impl Eval<Type, TypeError> for Type {
     fn eval(&self, ctx: &mut TypeContext) -> Result<Type, TypeError> {
         match self {
             t @ Type::Bool
+            | t @ Type::QBool
             | t @ Type::Int
+            | t @ Type::QInt
             | t @ Type::Top
             | t @ Type::TyAbs(_, _, _) => Ok(t.clone()),
             Type::Var(s) | Type::BoundedVar(s, _) => {
@@ -172,7 +174,12 @@ impl Eval<Type, TypeError> for Type {
                 Box::new(from.eval(ctx)?),
                 Box::new(to.eval(ctx)?),
             )),
+            Type::QArr(ref from, ref to) => Ok(Type::QArr(
+                Box::new(from.eval(ctx)?),
+                Box::new(to.eval(ctx)?),
+            )),
             Type::Record(fields) => Ok(Type::Record(fields.eval(ctx)?)),
+            Type::QRec(fields) => Ok(Type::QRec(fields.eval(ctx)?)),
             Type::All(s, ref ty) => {
                 ctx.push(s.clone(), Type::Var(s.clone()));
                 let result = Ok(Type::All(s.clone(), Box::new(ty.eval(ctx)?)));

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -43,6 +43,10 @@ pub Term: Box<Term> = {
             (arg, Some(ty)) => Term::Abs(arg, *ty, Box::new(func)),
             (arg, None) => Term::InfAbs(arg, Box::new(func))
         })),
+    "lin" FuncDef <p:TypedParams> "->" <t:Term> =>
+        p.into_iter()
+            .rev()
+            .fold(t, |func, (arg, ty)| Box::new(Term::QAbs(arg, *ty, func))),
     FuncDef "[" <univ:NECommaSep<TypeParam>> "]" <p:TypedParams> "->" <body:Term> => {
         let func = p
             .into_iter()
@@ -102,10 +106,14 @@ PathTerm: Box<Term> = {
 ATerm: Box<Term> = {
     Ident => Box::new(Term::Var(<>)),
     Num => Box::new(Term::Int(<>)),
+    "lin" <Num> => Box::new(Term::QInt(<>)),
     Bool => Box::new(Term::Bool(<>)),
+    "lin" <Bool> => Box::new(Term::Bool(<>)),
     "(" <Term> ")",
     "{" <CommaSep<RecordField>> "}" =>
         Box::new(Term::Record(AssocList::from_vec(<>))),
+    "lin" "{" <CommaSep<RecordField>> "}" =>
+        Box::new(Term::QRec(AssocList::from_vec(<>))),
     // TODO: is there a way to not have parentheses w/o shift/reduce conflicts
     "module" "ops" "type" <ty:Type> <impls:("val" <RecordField>)+> "end" "as" "(" <asc:Type> ")" =>
         Box::new(Term::Pack(*ty, AssocList::from_vec(impls), *asc)),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -193,6 +193,7 @@ pub Type: Box<Type> = {
 
 ArrowType: Box<Type> = {
     <AppType> "->" <ArrowType> => Box::new(Type::Arr(<>)),
+    "lin" "(" <AppType> "->" <AppType> ")" => Box::new(Type::QArr(<>)),
     AppType,
 }
 
@@ -205,8 +206,12 @@ AType: Box<Type> = {
     "(" <Type> ")",
     "{" <CommaSep<RecordFieldType>> "}" =>
         Box::new(Type::Record(AssocList::from_vec(<>))),
+    "lin" "{" <CommaSep<RecordFieldType>> "}" =>
+        Box::new(Type::QRec(AssocList::from_vec(<>))),
     "Bool" => Box::new(Type::Bool),
+    "lin Bool" => Box::new(Type::QBool),
     "Int" => Box::new(Type::Int),
+    "lin Int" => Box::new(Type::QInt),
     "Top" => Box::new(Type::Top),
     <TyIdent> => Box::new(Type::Var(<>)),
     "module" "sig" "type" <ty:TyIdent> <sigs:("val" <RecordFieldType>)+> "end" =>

--- a/src/kindcheck.rs
+++ b/src/kindcheck.rs
@@ -5,10 +5,14 @@ use syntax::{Kind, Type};
 pub fn kindcheck(ty: &Type, ctx: &mut KindContext) -> Result<Kind, KindError> {
     match ty {
         Type::Bool
+        | Type::QBool
         | Type::Int
+        | Type::QInt
         | Type::Top
         | Type::Arr(_, _)
+        | Type::QArr(_, _)
         | Type::Record(_)
+        | Type::QRec(_)
         | Type::All(_, _)
         | Type::KindedAll(_, _, _)
         | Type::BoundedAll(_, _, _)

--- a/src/syntax/ty.rs
+++ b/src/syntax/ty.rs
@@ -51,6 +51,14 @@ impl Type {
             _ => unimplemented!(),
         }
     }
+
+    pub fn is_linear_val(&self) -> bool {
+        use self::Type::*;
+        match self {
+            QBool | QInt | QRec(_) => true, // QArr has different type rules
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for Type {

--- a/src/syntax/ty.rs
+++ b/src/syntax/ty.rs
@@ -14,15 +14,9 @@ pub enum Type {
     // TODO: is this extra variant necessary?
     BoundedVar(String, Box<Type>),
     All(String, Box<Type>),
-    // This could encompass the All type by putting Top as the second type argument
-    // but with the way Terms and Types are shared across all typecheckers it
-    // is probably simpler to keep them separate for now. It also probably greatly
-    // increase the size of the generate parser
     BoundedAll(String, Box<Type>, Box<Type>),
     KindedAll(String, Box<Type>, Kind),
-    // The second parameter is a general Type in the TAPL implementation but
-    // currently it's only possible to instantiate a Type::Some with a Record type
-    // anyways so use an AssocList directly
+    // We only allow the value component of an existential to be a record
     Some(String, AssocList<String, Type>),
     TyAbs(String, Kind, Box<Type>),
     TyApp(Box<Type>, Box<Type>),

--- a/src/test_grammar.rs
+++ b/src/test_grammar.rs
@@ -269,7 +269,7 @@ pub mod tests {
     }
 
     #[test]
-    fn substructural_qualifiers() {
+    fn substructural() {
         assert!(grammar::TermParser::new().parse("lin 0").is_ok());
         assert!(
             grammar::TermParser::new()
@@ -279,6 +279,17 @@ pub mod tests {
         assert!(
             grammar::TermParser::new()
                 .parse("fun (x: Int) -> x + 1")
+                .is_ok()
+        );
+        assert!(
+            grammar::TypeParser::new()
+                .parse("lin (Int -> lin Bool)")
+                .is_ok()
+        );
+        assert!(grammar::TypeParser::new().parse("lin (lin Bool").is_err());
+        assert!(
+            grammar::TypeParser::new()
+                .parse("lin {x: lin Int, b: Bool}")
                 .is_ok()
         );
     }

--- a/src/test_grammar.rs
+++ b/src/test_grammar.rs
@@ -267,4 +267,19 @@ pub mod tests {
         assert!(grammar::KindParser::new().parse("* -> *").is_ok());
         assert!(grammar::KindParser::new().parse("* -> (* -> *)").is_ok());
     }
+
+    #[test]
+    fn substructural_qualifiers() {
+        assert!(grammar::TermParser::new().parse("lin 0").is_ok());
+        assert!(
+            grammar::TermParser::new()
+                .parse("lin {a=lin 0, b=true}")
+                .is_ok()
+        );
+        assert!(
+            grammar::TermParser::new()
+                .parse("fun (x: Int) -> x + 1")
+                .is_ok()
+        );
+    }
 }

--- a/src/typecheck/fomega.rs
+++ b/src/typecheck/fomega.rs
@@ -113,7 +113,11 @@ pub fn typecheck(
         | Term::InfAbs(_, _)
         | Term::Pack(_, _, _)
         | Term::Unpack(_, _, _, _)
-        | Term::BoundedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::BoundedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/fomsub.rs
+++ b/src/typecheck/fomsub.rs
@@ -128,7 +128,11 @@ pub fn typecheck(
         | Term::InfAbs(_, _)
         | Term::Pack(_, _, _)
         | Term::Unpack(_, _, _, _)
-        | Term::KindedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::KindedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/fsub.rs
+++ b/src/typecheck/fsub.rs
@@ -162,9 +162,12 @@ pub fn typecheck(term: &Term, ctx: &mut Context) -> Result<Type, TypeError> {
                 Err(TypeError::ExpectedSome)
             }
         }
-        Term::InfAbs(_, _) | Term::KindedTyAbs(_, _, _) => {
-            Err(TypeError::Unsupported)
-        }
+        Term::InfAbs(_, _)
+        | Term::KindedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/hm.rs
+++ b/src/typecheck/hm.rs
@@ -106,7 +106,11 @@ pub fn get_constraints(
         | Term::Pack(_, _, _)
         | Term::Unpack(_, _, _, _)
         | Term::KindedTyAbs(_, _, _)
-        | Term::BoundedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::BoundedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -20,4 +20,5 @@ pub mod hm;
 pub mod omega;
 pub mod simple;
 pub mod sub;
+pub mod substructural;
 pub mod sysf;

--- a/src/typecheck/omega.rs
+++ b/src/typecheck/omega.rs
@@ -88,7 +88,11 @@ pub fn typecheck(
         | Term::Pack(_, _, _)
         | Term::Unpack(_, _, _, _)
         | Term::KindedTyAbs(_, _, _)
-        | Term::BoundedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::BoundedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/simple.rs
+++ b/src/typecheck/simple.rs
@@ -84,7 +84,11 @@ pub fn typecheck(
         | Term::Pack(_, _, _)
         | Term::Unpack(_, _, _, _)
         | Term::KindedTyAbs(_, _, _)
-        | Term::BoundedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::BoundedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/simple.rs
+++ b/src/typecheck/simple.rs
@@ -113,19 +113,25 @@ impl Resolve for Type {
 pub fn has_ty_operators(ty: &Type) -> bool {
     match ty {
         Type::Bool
+        | Type::QBool
         | Type::Int
+        | Type::QInt
         | Type::Top
         | Type::Var(_)
         | Type::BoundedVar(_, _) => false,
         Type::TyAbs(_, _, _) | Type::TyApp(_, _) => true,
-        Type::Record(fields) | Type::Some(_, fields) => fields
-            .inner
-            .iter()
-            .any(|(_, ref val)| has_ty_operators(val)),
+        Type::Record(fields) | Type::Some(_, fields) | Type::QRec(fields) => {
+            fields
+                .inner
+                .iter()
+                .any(|(_, ref val)| has_ty_operators(val))
+        }
         Type::All(_, ref fun) | Type::KindedAll(_, ref fun, _) => {
             has_ty_operators(fun)
         }
-        Type::BoundedAll(_, ref l, ref r) | Type::Arr(ref l, ref r) => {
+        Type::BoundedAll(_, ref l, ref r)
+        | Type::Arr(ref l, ref r)
+        | Type::QArr(ref l, ref r) => {
             has_ty_operators(l) || has_ty_operators(r)
         }
     }

--- a/src/typecheck/sub.rs
+++ b/src/typecheck/sub.rs
@@ -90,7 +90,11 @@ pub fn typecheck(term: &Term, ctx: &mut Context) -> Result<Type, TypeError> {
         | Term::Pack(_, _, _)
         | Term::Unpack(_, _, _, _)
         | Term::KindedTyAbs(_, _, _)
-        | Term::BoundedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::BoundedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/typecheck/substructural.rs
+++ b/src/typecheck/substructural.rs
@@ -1,0 +1,174 @@
+use assoclist::TypeContext as Context;
+use errors::TypeError;
+use syntax::{Term, Type};
+use typecheck::simple::Resolve;
+
+export_kindless_typechecker!(typecheck);
+
+pub fn typecheck(
+    term: &Term,
+    context: &mut Context,
+) -> Result<Type, TypeError> {
+    match term {
+        Term::Bool(_) => Ok(Type::Bool),
+        Term::QBool(_) => Ok(Type::QBool),
+        Term::Int(_) => Ok(Type::Int),
+        Term::QInt(_) => Ok(Type::QInt),
+        Term::Not(box t) => match typecheck(t, context)? {
+            Type::Bool => Ok(Type::Bool),
+            _ => Err(TypeError::NegateNonBool),
+        },
+        Term::Var(s) => context
+            .lookup(s)
+            .and_then(|ty| {
+                if ty.is_qualified() {
+                    context.remove(s)
+                } else {
+                    Some(ty)
+                }
+            }).ok_or(TypeError::NameError(s.to_string())),
+        Term::QAbs(param, type_, box body) => {
+            let ty = type_.resolve(context)?;
+            context.push(param.clone(), ty.clone());
+            // TODO: code reuse
+            let out_type = match typecheck(body, context) {
+                Err(TypeError::NameError(ref s)) if s == param => {
+                    return Err(TypeError::Linear(s.clone()))
+                }
+                result => result,
+            };
+            let result = Ok(Type::QArr(Box::new(ty), Box::new(out_type?)));
+            context.pop();
+            result
+        }
+        Term::Abs(param, type_, box body) => {
+            let ty = type_.resolve(context)?;
+            if context.inner.iter().any(|(_, ty)| ty.is_qualified()) {
+                // TODO: more helpful error - pass closure maybe?
+                return Err(TypeError::AbsContainment);
+            }
+            context.push(param.clone(), ty.clone());
+            let out_type = match typecheck(body, context) {
+                Err(TypeError::NameError(ref s)) if s == param => {
+                    return Err(TypeError::Linear(s.clone()))
+                }
+                result => result,
+            };
+            let result = Ok(Type::Arr(Box::new(ty), Box::new(out_type?)));
+            context.pop();
+            result
+        }
+        Term::App(box func, box val) => match typecheck(func, context)? {
+            Type::Arr(box in_type, box out_type)
+            | Type::QArr(box in_type, box out_type) => {
+                match typecheck(val, context)? {
+                    ref t if *t == in_type => Ok(out_type.clone()),
+                    t => Err(TypeError::ArgMismatch(in_type, t)),
+                }
+            }
+            _ => Err(TypeError::FuncApp),
+        },
+        Term::Arith(box left, op, box right) => {
+            match (typecheck(left, context)?, typecheck(right, context)?) {
+                (Type::Int, Type::Int)
+                | (Type::QInt, Type::Int)
+                | (Type::Int, Type::QInt)
+                | (Type::QInt, Type::QInt) => Ok(op.return_type()),
+                (l, r) => Err(TypeError::Arith(*op, l, r)),
+            }
+        }
+        Term::Logic(box left, op, box right) => {
+            match (typecheck(left, context)?, typecheck(right, context)?) {
+                (Type::Bool, Type::Bool)
+                | (Type::QBool, Type::Bool)
+                | (Type::Bool, Type::QBool)
+                | (Type::QBool, Type::QBool) => Ok(Type::Bool),
+                (l, r) => Err(TypeError::Logic(*op, l, r)),
+            }
+        }
+        Term::If(box cond, box if_, box else_) => {
+            let condtype = typecheck(cond, context)?;
+            let mut copied = context.clone();
+
+            let left = typecheck(if_, context)?;
+            let right = typecheck(else_, &mut copied)?;
+            if condtype != Type::Bool {
+                Err(TypeError::IfElseCond)
+            } else if left != right {
+                Err(TypeError::IfElseArms(left, right))
+            } else {
+                Ok(left)
+            }
+        }
+        Term::Let(varname, box val, box term) => {
+            let val_type = typecheck(val, context)?;
+            context.push(varname.clone(), val_type);
+            let result = match typecheck(term, context) {
+                Err(TypeError::NameError(ref s)) if s == varname => {
+                    return Err(TypeError::Linear(s.clone()))
+                }
+                result => result,
+            };
+            context.pop();
+            Ok(result?)
+        }
+        Term::Record(fields) => {
+            Ok(Type::Record(fields.map_typecheck(typecheck, context)?))
+        }
+        Term::Proj(box term, key) => match typecheck(term, context)? {
+            Type::Record(fields) => fields
+                .lookup(&key)
+                .ok_or(TypeError::InvalidKey(key.clone())),
+            _ => Err(TypeError::ProjectNonRecord),
+        },
+        Term::TyAbs(_, _)
+        | Term::TyApp(_, _)
+        | Term::InfAbs(_, _)
+        | Term::Pack(_, _, _)
+        | Term::Unpack(_, _, _, _)
+        | Term::KindedTyAbs(_, _, _)
+        | Term::BoundedTyAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use assoclist::TypeContext;
+    use grammar;
+
+    pub fn typecheck_code(code: &str) -> String {
+        typecheck(
+            &grammar::TermParser::new().parse(code).unwrap(),
+            &mut TypeContext::empty(),
+        ).map(|ty| ty.to_string())
+        .unwrap_or_else(|err| err.to_string())
+    }
+
+    #[test]
+    fn e2e_type() {
+        assert_eq!(typecheck_code("let x = lin 1 in x + 1"), "Int");
+        assert_eq!(
+            typecheck_code("let x = lin 1 in x + x"),
+            "Linear variable x must be used exactly once"
+        );
+        // discard function
+        assert_eq!(
+            typecheck_code(
+                "lin fun (x: lin Bool) ->
+                    (lin fun (f: Bool -> lin Bool) -> lin true)
+                    (fun (y: Bool) -> x)"),
+            "Unrestricted functions cannot have linear variables in scope");
+        assert_eq!(
+            typecheck_code("let x = lin 1 in if true then x + 1 else x - 1"),
+            "Int");
+        assert_eq!(typecheck_code("let x = 1 in x + x"), "Int");
+        assert_eq!(typecheck_code("fun (x: Int) -> x + 1"), "(Int -> Int)");
+        assert_eq!(typecheck_code("fun (x: lin Int) -> x + 1"), "(lin Int -> Int)");
+        assert_eq!(
+            typecheck_code("fun (x: lin Int) -> x + x"),
+            "Linear variable x must be used exactly once");
+        assert_eq!(typecheck_code("lin fun (x: lin Int) -> x"), "lin (lin Int -> lin Int)");
+    }
+}

--- a/src/typecheck/sysf.rs
+++ b/src/typecheck/sysf.rs
@@ -128,7 +128,11 @@ pub fn typecheck(
         }
         Term::InfAbs(_, _)
         | Term::BoundedTyAbs(_, _, _)
-        | Term::KindedTyAbs(_, _, _) => Err(TypeError::Unsupported),
+        | Term::KindedTyAbs(_, _, _)
+        | Term::QBool(_)
+        | Term::QInt(_)
+        | Term::QAbs(_, _, _)
+        | Term::QRec(_) => Err(TypeError::Unsupported),
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -27,6 +27,7 @@ pub fn set_typechecker(serialized: u8) {
             0b0000_1101 => ::typecheck::fomsub::typecheck,
             // TODO: remove the possibility of subtyping and higher order only
             0b0000_1001 => ::typecheck::fomsub::typecheck,
+            0b0010_0000 => ::typecheck::substructural::typecheck_top,
             _ => unimplemented!(),
         })
     }

--- a/www/index.js
+++ b/www/index.js
@@ -34,6 +34,7 @@ const combinations = [
     [true, false, true, false, false, false],
     [false, true, false, false, false, false],
     [true, false, true, true, false, false],
+    [true, false, false, false, false, true],
 ];
 
 const updateOptions = () => {


### PR DESCRIPTION
Add substructural type system based mainly on the first chapter of ATTAPL. It's not ideal to have to add a new term for each existing term that can be qualified (e.g. have a Term::Int in addition to a Term::QInt), but this follows the convention of keeping different type features in separate variants of Term/Type and I think it's better than the alternative (in each existing typechecker, would need to change the match arm for each qualified term to then match on the qualifier - it's more code I think and it makes other typecheckers need to know about qualifiers themselves). The other thing that would be nice to get around is the need to take into consideration each possible combination of Int/QInt of Bool/QBool in the arithmetic/logical operations. Maybe this is unavoidable in the current system but can be simplified with subtyping/polymorphism.

Still todo:
- [x] enforce usage of linear types (right now they are more like affine)
- [ ] add other qualifiers (relevant, affine, ordered)?
